### PR TITLE
Fixed wrong index for keypairs

### DIFF
--- a/HLSPlayerSDK/src/com/kaltura/hlsplayersdk/manifest/ManifestPlaylist.java
+++ b/HLSPlayerSDK/src/com/kaltura/hlsplayersdk/manifest/ManifestPlaylist.java
@@ -23,7 +23,7 @@ public class ManifestPlaylist extends BaseManifestItem {
 		int firstCommaIndex = input.indexOf(',');
 		int firstEqualSignIndex = input.indexOf('=');
 		int firstQuoteIndex = input.indexOf('"');
-		int endIndex = firstCommaIndex > -1 ? firstCommaIndex : input.length() + 1;
+		int endIndex = firstCommaIndex > -1 ? firstCommaIndex : input.length() - 1;
 		
 		String key = input.substring( 0, firstEqualSignIndex ).trim();
 		String value;


### PR DESCRIPTION
endIndex should be input.length() - 1 instead of input.length + 1.